### PR TITLE
Create empty file in initial commit

### DIFF
--- a/init-with-feature-branches.sh
+++ b/init-with-feature-branches.sh
@@ -45,8 +45,10 @@ pushd $DEV1 > /dev/null
 git init >/dev/null
 
 touch .initial-checkin
+touch $FILE
 git add .initial-checkin
-git commit -m "Initial Checkin" >/dev/null 2>/dev/null
+git add $FILE
+git commit -m "Initial Checkin. Create empty $FILE" >/dev/null 2>/dev/null
 
 
 #

--- a/init.sh
+++ b/init.sh
@@ -44,8 +44,10 @@ pushd $DEV1 > /dev/null
 git init >/dev/null
 
 touch .initial-checkin
+touch $FILE
 git add .initial-checkin
-git commit -m "Initial Checkin" >/dev/null 2>/dev/null
+git add $FILE
+git commit -m "Initial Checkin. Create empty $FILE" >/dev/null 2>/dev/null
 
 
 #


### PR DESCRIPTION
Add creation of empty file in initial commit.

This way when performing the task:

`Switch the order of commits 01-first-will-conflict and 02-second-will-conflict`

One will face more common situation of merge conflict that usually shall require usage of dedicated mergetool as `kdiff3` , `meld`, `beyond compare` etc. instead having more rare prompt where the file was not indexed by git before, which prompts e.g.:

```
Deleted merge conflict for 'file.txt':
  {local}: deleted
  {remote}: modified file
Use (m)odified or (d)eleted file, or (a)bort? m
```